### PR TITLE
Fix deprecation warnings with transformers < 4

### DIFF
--- a/Control/Monad/StateStack.hs
+++ b/Control/Monad/StateStack.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving
+{-# LANGUAGE CPP
+           , GeneralizedNewtypeDeriving
            , FlexibleInstances
            , MultiParamTypeClasses
   #-}
@@ -64,7 +65,11 @@ import Control.Arrow (first, (&&&))
 
 import Control.Monad.Trans
 import Control.Monad.Trans.Cont
+#if MIN_VERSION_transformers(0,4,0)
+import Control.Monad.Trans.Except
+#else
 import Control.Monad.Trans.Error
+#endif
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
@@ -151,7 +156,11 @@ instance MonadStateStack s m => MonadStateStack s (ContT r m) where
   save    = lift save
   restore = lift restore
 
+#if MIN_VERSION_transformers(0,4,0)
+instance MonadStateStack s m => MonadStateStack s (ExceptT e m) where
+#else
 instance (Error e, MonadStateStack s m) => MonadStateStack s (ErrorT e m) where
+#endif
   save    = lift save
   restore = lift restore
 


### PR DESCRIPTION
My fix for issue #1. This uses CPP pragmas to conditionally use the deprecated `ErrorT` (if using an old version of `transformers`) or `ExceptT` (if using a recent version). This way, the version bounds for `transformers` do not have to be changed, and the deprecation errors should go away.
