### PR TITLE
Use transformers-compat to get around deprecation warnings

### DIFF
--- a/Control/Monad/StateStack.hs
+++ b/Control/Monad/StateStack.hs
@@ -3,6 +3,9 @@
            , FlexibleInstances
            , MultiParamTypeClasses
   #-}
+#if !(MIN_VERSION_mtl(2,2,0))
+{-# LANGUAGE UndecidableInstances #-}
+#endif
 
 -----------------------------------------------------------------------------
 -- |

--- a/Control/Monad/StateStack.hs
+++ b/Control/Monad/StateStack.hs
@@ -64,7 +64,7 @@ import Control.Arrow (first, (&&&))
 
 import Control.Monad.Trans
 import Control.Monad.Trans.Cont
-import Control.Monad.Trans.Error
+import Control.Monad.Trans.Except
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
@@ -151,7 +151,7 @@ instance MonadStateStack s m => MonadStateStack s (ContT r m) where
   save    = lift save
   restore = lift restore
 
-instance (Error e, MonadStateStack s m) => MonadStateStack s (ErrorT e m) where
+instance MonadStateStack s m => MonadStateStack s (ExceptT e m) where
   save    = lift save
   restore = lift restore
 

--- a/Control/Monad/StateStack.hs
+++ b/Control/Monad/StateStack.hs
@@ -1,12 +1,7 @@
-{-# LANGUAGE CPP
-           , GeneralizedNewtypeDeriving
+{-# LANGUAGE GeneralizedNewtypeDeriving
            , FlexibleInstances
            , MultiParamTypeClasses
   #-}
-#if !(MIN_VERSION_mtl(2,2,0))
-{-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -63,6 +58,7 @@ module Control.Monad.StateStack
 import Data.Monoid
 import Control.Applicative
 import Control.Arrow (second)
+import Control.Monad.Except ()
 import Control.Monad.Identity
 import qualified Control.Monad.State as St
 import Control.Arrow (first, (&&&))
@@ -208,14 +204,3 @@ instance RC.MonadReader r m => RC.MonadReader r (StateStackT s m) where
   ask     = lift RC.ask
   local f = StateStackT . RC.local f . unStateStackT
 -}
-
-------------------------------------------------------------
---  MonadState instance for ExceptT for older mtl versions
-------------------------------------------------------------
-
-#if !(MIN_VERSION_mtl(2,2,0))
-instance St.MonadState s m => St.MonadState s (ExceptT e m) where
-    get   = lift StC.get
-    put   = lift . StC.put
-    state = lift . StC.state
-#endif

--- a/Control/Monad/StateStack.hs
+++ b/Control/Monad/StateStack.hs
@@ -5,6 +5,7 @@
   #-}
 #if !(MIN_VERSION_mtl(2,2,0))
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 #endif
 
 -----------------------------------------------------------------------------

--- a/Control/Monad/StateStack.hs
+++ b/Control/Monad/StateStack.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving
+{-# LANGUAGE CPP
+           , GeneralizedNewtypeDeriving
            , FlexibleInstances
            , MultiParamTypeClasses
   #-}
@@ -203,3 +204,14 @@ instance RC.MonadReader r m => RC.MonadReader r (StateStackT s m) where
   ask     = lift RC.ask
   local f = StateStackT . RC.local f . unStateStackT
 -}
+
+------------------------------------------------------------
+--  MonadState instance for ExceptT for older mtl versions
+------------------------------------------------------------
+
+#if !(MIN_VERSION_mtl(2,2,0))
+instance St.MonadState s m => St.MonadState s (ExceptT e m) where
+    get   = lift get
+    put   = lift . put
+    state = lift . state
+#endif

--- a/Control/Monad/StateStack.hs
+++ b/Control/Monad/StateStack.hs
@@ -211,7 +211,7 @@ instance RC.MonadReader r m => RC.MonadReader r (StateStackT s m) where
 
 #if !(MIN_VERSION_mtl(2,2,0))
 instance St.MonadState s m => St.MonadState s (ExceptT e m) where
-    get   = lift get
-    put   = lift . put
-    state = lift . state
+    get   = lift StC.get
+    put   = lift . StC.put
+    state = lift . StC.state
 #endif

--- a/Control/Monad/StateStack.hs
+++ b/Control/Monad/StateStack.hs
@@ -58,7 +58,6 @@ module Control.Monad.StateStack
 import Data.Monoid
 import Control.Applicative
 import Control.Arrow (second)
-import Control.Monad.Except ()
 import Control.Monad.Identity
 import qualified Control.Monad.State as St
 import Control.Arrow (first, (&&&))

--- a/statestack.cabal
+++ b/statestack.cabal
@@ -21,6 +21,5 @@ Library
   Exposed-modules:     Control.Monad.StateStack
   Build-depends:       base >= 4.2 && < 4.9,
                        mtl >= 2.1 && < 2.3,
-                       mtl-compat >= 0.1 && < 0.2,
                        transformers >= 0.3 && < 0.5,
-                       transformers-compat >= 0.3 && < 0.4
+                       transformers-compat >= 0.4 && < 0.5

--- a/statestack.cabal
+++ b/statestack.cabal
@@ -21,5 +21,6 @@ Library
   Exposed-modules:     Control.Monad.StateStack
   Build-depends:       base >= 4.2 && < 4.8,
                        mtl >= 2.1 && < 2.3,
+                       mtl-compat >= 0.1 && < 0.2,
                        transformers >= 0.3 && < 0.5,
                        transformers-compat >= 0.3 && < 0.4

--- a/statestack.cabal
+++ b/statestack.cabal
@@ -21,4 +21,5 @@ Library
   Exposed-modules:     Control.Monad.StateStack
   Build-depends:       base >= 4.2 && < 4.8,
                        mtl >= 2.1 && < 2.3,
-                       transformers >= 0.3 && < 0.5
+                       transformers >= 0.3 && < 0.5,
+                       transformers-compat >= 0.3 && < 0.4


### PR DESCRIPTION
My second attempt (after [this one](https://github.com/diagrams/statestack/pull/2)) to fix issue #1. This uses the `transformers-compat` library to provide users access to `ExceptT`, even if they are using an older version of `transformers`. This allows `statestack` to avoid all warnings about `ErrorT` being deprecated.
