### PR TITLE
Compatibility with mtl-2.3

### DIFF
--- a/Control/Monad/StateStack.hs
+++ b/Control/Monad/StateStack.hs
@@ -59,6 +59,7 @@ import           Control.Arrow                     (second)
 import           Control.Arrow                     (first, (&&&))
 import qualified Control.Monad.State               as St
 
+import           Control.Monad
 import           Control.Monad.Identity
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Cont

--- a/statestack.cabal
+++ b/statestack.cabal
@@ -21,5 +21,5 @@ Library
   Default-language:    Haskell2010
   Exposed-modules:     Control.Monad.StateStack
   Build-depends:       base >= 4.8 && < 4.18,
-                       mtl >= 2.1 && < 2.3,
+                       mtl >= 2.1 && < 2.4,
                        transformers >= 0.4 && < 0.7


### PR DESCRIPTION
`mtl-2.3.1` dropped reexports from Control.Monad so `import Control.Monad`.